### PR TITLE
Fix Map initialization from object entries in recipe cache hooks

### DIFF
--- a/core/dynamo/hooks/use_dynamo_delete.ts
+++ b/core/dynamo/hooks/use_dynamo_delete.ts
@@ -17,9 +17,9 @@ const useDeleteRecipeInCache = () => {
       queryClient.getQueryData(mealPlanKey);
 
     if (previousRecipes) {
-      const updatedRecipes = new Map(previousRecipes);
+      const updatedRecipes = new Map(Object.entries(previousRecipes));
       updatedRecipes.delete(recipeId);
-      queryClient.setQueryData(recipesKey, updatedRecipes);
+      queryClient.setQueryData(recipesKey, Object.fromEntries(updatedRecipes));
     }
 
     if (previousMealPlan) {

--- a/core/dynamo/hooks/use_dynamo_put.ts
+++ b/core/dynamo/hooks/use_dynamo_put.ts
@@ -21,9 +21,9 @@ const useMutateRecipeInCache = () => {
       queryClient.getQueryData(recipesKey);
 
     if (previousRecipes) {
-      const updatedRecipes = new Map(previousRecipes);
+      const updatedRecipes = new Map(Object.entries(previousRecipes));
       updatedRecipes.set(recipe.uuid, recipe);
-      queryClient.setQueryData(recipesKey, updatedRecipes);
+      queryClient.setQueryData(recipesKey, Object.fromEntries(updatedRecipes));
     }
 
     return {

--- a/core/dynamo/hooks/use_parse_recipe.ts
+++ b/core/dynamo/hooks/use_parse_recipe.ts
@@ -33,7 +33,7 @@ export const useParsedRecipeToDynamo = () => {
         queryClient.getQueryData(recipesKey);
 
       if (previousRecipes) {
-        const updatedRecipes = new Map(previousRecipes);
+        const updatedRecipes = new Map(Object.entries(previousRecipes));
         // Use the recipeId if provided (editing), otherwise use the parsed UUID (new recipe)
         const recipeUuid = recipeId || parsedRecipe.uuid;
         updatedRecipes.set(recipeUuid, parsedRecipe as any);


### PR DESCRIPTION
## Summary
Fixed Map initialization and serialization in recipe cache management hooks to properly handle object-to-Map conversions and vice versa.

## Key Changes
- Updated `useDeleteRecipeInCache` hook to convert object entries before Map initialization and convert Map back to object before storing in query cache
- Updated `useMutateRecipeInCache` hook with the same Map initialization and serialization pattern
- Updated `useParsedRecipeToDynamo` hook to properly initialize Map from object entries

## Implementation Details
The changes ensure consistent handling of recipe data structures across cache operations:
- When creating a Map from `previousRecipes` (an object), now explicitly converts using `Object.entries()` first
- When storing the updated Map back to the query cache, converts back to a plain object using `Object.fromEntries()`

This fixes a potential issue where Maps were being created directly from objects, which may not have properly initialized the key-value pairs. The pattern now ensures proper serialization/deserialization between the object-based query cache and Map-based mutations.

https://claude.ai/code/session_018r8Sx3kQLVJR7scD4D9J2H