### PR TITLE
Hide amount and unit when unit is "none" in ingredients list

### DIFF
--- a/components/recipe-part.tsx
+++ b/components/recipe-part.tsx
@@ -87,10 +87,12 @@ function IngredientsList({
                   {isChecked && <Check className="size-3" />}
                 </span>
                 <span className={isChecked ? "line-through" : ""}>
-                  <span className="font-medium">
-                    {item.amount}
-                    {item.unit ? ` ${item.unit}` : ""}
-                  </span>{" "}
+                  {item.unit !== "none" && (
+                    <span className="font-medium">
+                      {item.amount}
+                      {item.unit ? ` ${item.unit}` : ""}
+                    </span>
+                  )}{" "}
                   {item.name}
                 </span>
               </button>

--- a/kitchencalmredesign/components/recipe-part.tsx
+++ b/kitchencalmredesign/components/recipe-part.tsx
@@ -87,10 +87,12 @@ function IngredientsList({
                   {isChecked && <Check className="size-3" />}
                 </span>
                 <span className={isChecked ? "line-through" : ""}>
-                  <span className="font-medium">
-                    {item.amount}
-                    {item.unit ? ` ${item.unit}` : ""}
-                  </span>{" "}
+                  {item.unit !== "none" && (
+                    <span className="font-medium">
+                      {item.amount}
+                      {item.unit ? ` ${item.unit}` : ""}
+                    </span>
+                  )}{" "}
                   {item.name}
                 </span>
               </button>


### PR DESCRIPTION
## Summary
Updated the ingredients list rendering to conditionally display the amount and unit only when the unit value is not "none", improving the presentation of ingredients that don't require quantity specifications.

## Key Changes
- Added a conditional check (`item.unit !== "none"`) around the amount and unit display in the ingredients list
- The amount and unit span is now only rendered when the unit is not "none"
- The ingredient name continues to display regardless of the unit value

## Implementation Details
The change wraps the `<span>` containing `item.amount` and `item.unit` in a conditional render. This allows ingredients with a unit value of "none" to display only their name without unnecessary quantity information, while maintaining the existing formatting and styling for ingredients with valid units.

https://claude.ai/code/session_0126LR3u9ZYQTVvnEop8bzMP