### PR TITLE
Fix recipe sidebar scrolling in meal planner layout

### DIFF
--- a/components/connected-meal-planner.tsx
+++ b/components/connected-meal-planner.tsx
@@ -207,7 +207,7 @@ export function ConnectedMealPlanner() {
       {/* Desktop: side-by-side layout */}
       <div className="hidden lg:flex lg:gap-6">
         <aside className="w-[280px] shrink-0">
-          <div className="sticky top-24">
+          <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-hidden flex flex-col">
             <RecipeSidebar recipes={sidebarRecipes} searchString={searchString} onSearchChange={setSearchString} />
           </div>
         </aside>

--- a/components/meal-planner/recipe-sidebar.tsx
+++ b/components/meal-planner/recipe-sidebar.tsx
@@ -14,9 +14,9 @@ interface RecipeSidebarProps {
 
 export function RecipeSidebar({ recipes, searchString, onSearchChange }: RecipeSidebarProps) {
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 min-h-0">
       <SearchBar searchString={searchString} onSearchChange={onSearchChange} />
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2 overflow-y-auto min-h-0">
         {recipes.map((recipe) => (
           <DraggableRecipe key={recipe.title} recipe={recipe} />
         ))}


### PR DESCRIPTION
## Summary
Fixed scrolling behavior in the recipe sidebar to properly handle overflow content while maintaining the sticky positioning in the desktop layout.

## Key Changes
- Added `min-h-0` to the recipe sidebar container to enable proper flex child sizing
- Added `overflow-y-auto` and `min-h-0` to the recipe list container to enable vertical scrolling of individual recipes
- Updated the sticky container to include `max-h-[calc(100vh-7rem)]`, `overflow-hidden`, and `flex flex-col` to constrain the sidebar height and properly contain scrollable content

## Implementation Details
These changes address a common flexbox issue where overflow content wasn't scrolling properly. By adding `min-h-0` to flex containers, we allow them to shrink below their content size, enabling the `overflow-y-auto` on the recipe list to function correctly. The sticky container now has an explicit max-height constraint (viewport height minus 7rem for the header) to prevent it from expanding beyond the visible area, while the `flex flex-col` ensures proper layout of its children.

https://claude.ai/code/session_012adCVZvQ6aCWZoBtyjP19N