### PR TITLE
Update app header navigation styling to use underline indicator

### DIFF
--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -67,10 +67,10 @@ export function AppHeader() {
                 <Link key={link.href} href={link.href} passHref>
                   <span
                     className={cn(
-                      "text-sm px-3 py-2 rounded-md cursor-pointer transition-colors",
+                      "text-sm px-3 py-2 cursor-pointer transition-colors border-b-2",
                       isActive
-                        ? "bg-primary/10 text-primary font-medium"
-                        : "text-muted-foreground hover:text-foreground hover:bg-accent"
+                        ? "border-primary text-primary font-medium"
+                        : "border-transparent text-muted-foreground hover:text-foreground"
                     )}
                   >
                     {link.label}


### PR DESCRIPTION
## Summary
Changed the app header navigation link styling from a background-based active state indicator to an underline-based indicator using a bottom border.

## Key Changes
- Replaced `rounded-md` with `border-b-2` to add a bottom border to all navigation links
- Updated active state styling from `bg-primary/10 text-primary` to `border-primary text-primary` for a cleaner underline effect
- Simplified inactive state styling by removing `hover:bg-accent` and keeping only text color changes on hover
- Maintained font weight and transition effects for consistency

## Implementation Details
The navigation links now use a bottom border indicator pattern instead of a background highlight. Active links display a primary-colored bottom border, while inactive links show a transparent border that becomes visible on hover through text color changes. This provides a more modern, minimalist navigation appearance commonly seen in contemporary web applications.

https://claude.ai/code/session_01F21U6ZKVatpt87gMQ8jhWV