### PR TITLE
Use DialogTitle component in recipe detail dialog

### DIFF
--- a/components/recipe-detail-dialog.tsx
+++ b/components/recipe-detail-dialog.tsx
@@ -1,6 +1,7 @@
 import {
   Dialog,
   DialogContent,
+  DialogTitle,
 } from "@/components/ui/dialog";
 import { RecipeCard } from "./recipe-card";
 import { RecipeActions } from "./recipe-actions";
@@ -41,9 +42,9 @@ export function RecipeDetailDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-3xl sm:max-w-3xl max-h-[90vh] p-0 gap-0 overflow-hidden">
         <div className="flex items-center justify-between border-b border-border px-5 py-3">
-          <h2 className="font-serif text-lg text-foreground">
+          <DialogTitle className="font-serif text-lg">
             {v0Recipe.title}
-          </h2>
+          </DialogTitle>
         </div>
         <div className="overflow-y-auto max-h-[calc(90vh-60px)]">
           <div className="p-1">


### PR DESCRIPTION
## Summary
Updated the recipe detail dialog to use the semantic `DialogTitle` component from the UI library instead of a plain `h2` element for the recipe title.

## Key Changes
- Imported `DialogTitle` from the dialog UI component library
- Replaced the `<h2>` element with `<DialogTitle>` component for the recipe title
- Maintained existing styling with `font-serif text-lg` classes on the DialogTitle component
- Removed the explicit `text-foreground` class (likely handled by DialogTitle's default styling)

## Implementation Details
This change improves semantic HTML structure and ensures proper accessibility by using the dedicated dialog title component. The DialogTitle component is the appropriate semantic element for dialog headers and may provide additional accessibility features or styling consistency with the dialog component library.

https://claude.ai/code/session_01RcAMmj3Xz49KucPXBvN3Xc