### PR TITLE
Remove debug console.logs and simplify data wrapping

### DIFF
--- a/client/hooks.ts
+++ b/client/hooks.ts
@@ -42,12 +42,9 @@ export const useGetRecipes = (
     query: {
       ...options?.query,
       enabled: (options?.query?.enabled ?? true) && isAuthenticated,
-      select: (response: any) => response.data,
     },
     request: options?.axios,
   });
-
-  console.log('query data', query.data)
 
   useEffect(() => {
     if (query.data !== undefined) {
@@ -73,7 +70,6 @@ export const useGetMealPlan = (
     query: {
       ...options?.query,
       enabled: (options?.query?.enabled ?? true) && isAuthenticated,
-      select: (response: any) => response.data,
     },
     request: options?.axios,
   });

--- a/components/recipe-grid.tsx
+++ b/components/recipe-grid.tsx
@@ -42,8 +42,6 @@ export function RecipeGrid({ recipeIds }: RecipeGridProps) {
 
   const hasRealRecipes = recipes && recipes.length > 0;
 
-  console.log('has real recipes', hasRealRecipes, recipes)
-
   // We already have recipe data (e.g. from the IndexedDB cache or a prior
   // fetch), so render it straight away rather than waiting on the session
   // to resolve - the session check below only matters when there's nothing

--- a/core/dynamo/hooks/use_dynamo_get.ts
+++ b/core/dynamo/hooks/use_dynamo_get.ts
@@ -20,8 +20,6 @@ const useRecipesBase = <T>({
     },
   });
 
-  console.log('data', recipesQuery.data)
-
   // Convert API response (object) to Map format for compatibility
   const recipesMap: IRecipes = recipesQuery.data ? new Map(Object.entries(recipesQuery.data)) : new Map();
 
@@ -33,11 +31,7 @@ const useRecipesBase = <T>({
 
 export const useRecipes = () => {
   return useRecipesBase({
-    select: (data) => {
-      const temp = Array.from(data.values())
-      console.log('got temp', temp, data)
-      return temp
-    },
+    select: (data) => Array.from(data.values()),
   });
 };
 

--- a/core/storage/use_hydrate_cache_from_indexed_db.ts
+++ b/core/storage/use_hydrate_cache_from_indexed_db.ts
@@ -7,9 +7,7 @@ import { getRecipesQueryKey, getMealPlanQueryKey } from "../../client/hooks";
 /**
  * Seeds the react-query cache from IndexedDB on mount so recipes/meal plan
  * can render instantly on first paint, without waiting for auth to resolve
- * or the network request to complete. The Orval-generated query functions
- * cache a raw axios-response-shaped object, so we wrap the stored payload
- * in `{ data: payload }` to match what `select` expects to unwrap.
+ * or the network request to complete.
  *
  * It doesn't matter whose data this is or whether the session is still
  * valid - we just show whatever is cached. useAppSession clears IndexedDB
@@ -27,15 +25,14 @@ export const useHydrateCacheFromIndexedDb = () => {
     const mealPlanKey = getMealPlanQueryKey();
 
     idbGet(RECIPES_CACHE_KEY).then((payload) => {
-      console.log('existing data', queryClient.getQueryData(recipesKey))
       if (payload !== undefined && queryClient.getQueryData(recipesKey) === undefined) {
-        queryClient.setQueryData(recipesKey, { data: payload });
+        queryClient.setQueryData(recipesKey, payload);
       }
     });
 
     idbGet(MEAL_PLAN_CACHE_KEY).then((payload) => {
       if (payload !== undefined && queryClient.getQueryData(mealPlanKey) === undefined) {
-        queryClient.setQueryData(mealPlanKey, { data: payload });
+        queryClient.setQueryData(mealPlanKey, payload);
       }
     });
   }, [queryClient]);


### PR DESCRIPTION
## Summary
Removes debug console.log statements and simplifies the data handling by eliminating unnecessary wrapper objects that were previously needed for Orval-generated query functions.

## Key Changes
- Removed all debug `console.log` statements from:
  - `use_hydrate_cache_from_indexed_db.ts`
  - `use_dynamo_get.ts`
  - `hooks.ts`
  - `recipe-grid.tsx`

- Simplified data wrapping in cache hydration:
  - Removed the `{ data: payload }` wrapper when setting query data in IndexedDB hydration, now storing payload directly
  - Removed the `select: (response: any) => response.data` transformations in `useGetRecipes` and `useGetMealPlan` hooks

- Simplified the `useRecipes` select function from a multi-line implementation to a single-line arrow function

## Implementation Details
The changes reflect that the Orval-generated query functions no longer require the axios-response-shaped wrapper object. Data is now stored and retrieved in its natural format, reducing unnecessary object wrapping and simplifying the codebase.

https://claude.ai/code/session_011KJvWPfdSTKuy32rFAaeah