### PR TITLE
Fix recipes/meal plan not rendering due to double-unwrapped cache data

### DIFF
--- a/client/hooks.ts
+++ b/client/hooks.ts
@@ -42,12 +42,9 @@ export const useGetRecipes = (
     query: {
       ...options?.query,
       enabled: (options?.query?.enabled ?? true) && isAuthenticated,
-      select: (response: any) => response.data,
     },
     request: options?.axios,
   });
-
-  console.log('query data', query.data)
 
   useEffect(() => {
     if (query.data !== undefined) {
@@ -73,7 +70,6 @@ export const useGetMealPlan = (
     query: {
       ...options?.query,
       enabled: (options?.query?.enabled ?? true) && isAuthenticated,
-      select: (response: any) => response.data,
     },
     request: options?.axios,
   });

--- a/components/recipe-grid.tsx
+++ b/components/recipe-grid.tsx
@@ -42,8 +42,6 @@ export function RecipeGrid({ recipeIds }: RecipeGridProps) {
 
   const hasRealRecipes = recipes && recipes.length > 0;
 
-  console.log('has real recipes', hasRealRecipes, recipes)
-
   // We already have recipe data (e.g. from the IndexedDB cache or a prior
   // fetch), so render it straight away rather than waiting on the session
   // to resolve - the session check below only matters when there's nothing

--- a/core/dynamo/hooks/use_dynamo_delete.ts
+++ b/core/dynamo/hooks/use_dynamo_delete.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from "axios";
 import { RecipeUuid } from "../../types/recipes";
 import { useAppSession } from "../../hooks/use_app_session";
 import { useQueryClient } from "@tanstack/react-query";
@@ -11,20 +10,20 @@ const useDeleteRecipeInCache = () => {
   const mealPlanKey = getMealPlanQueryKey();
 
   return (recipeId: RecipeUuid) => {
-    const previousRecipesCache = queryClient.getQueryData<AxiosResponse<GetKitchencalmRecipes200>>(recipesKey);
-    const previousMealPlanCache = queryClient.getQueryData<AxiosResponse<MealPlan>>(mealPlanKey);
+    const previousRecipesCache = queryClient.getQueryData<GetKitchencalmRecipes200>(recipesKey);
+    const previousMealPlanCache = queryClient.getQueryData<MealPlan>(mealPlanKey);
 
-    if (previousRecipesCache?.data) {
-      const { [recipeId]: _removed, ...remainingRecipes } = previousRecipesCache.data;
-      queryClient.setQueryData(recipesKey, { ...previousRecipesCache, data: remainingRecipes });
+    if (previousRecipesCache) {
+      const { [recipeId]: _removed, ...remainingRecipes } = previousRecipesCache;
+      queryClient.setQueryData(recipesKey, remainingRecipes);
     }
 
-    if (previousMealPlanCache?.data && Array.isArray(previousMealPlanCache.data)) {
-      const updatedMealPlan = previousMealPlanCache.data.map((item) => ({
+    if (previousMealPlanCache && Array.isArray(previousMealPlanCache)) {
+      const updatedMealPlan = previousMealPlanCache.map((item) => ({
         ...item,
         plan: item.plan.filter((r) => r.recipeId !== recipeId),
       }));
-      queryClient.setQueryData(mealPlanKey, { ...previousMealPlanCache, data: updatedMealPlan });
+      queryClient.setQueryData(mealPlanKey, updatedMealPlan);
     }
 
     return {

--- a/core/dynamo/hooks/use_dynamo_get.ts
+++ b/core/dynamo/hooks/use_dynamo_get.ts
@@ -20,8 +20,6 @@ const useRecipesBase = <T>({
     },
   });
 
-  console.log('data', recipesQuery.data)
-
   // Convert API response (object) to Map format for compatibility
   const recipesMap: IRecipes = recipesQuery.data ? new Map(Object.entries(recipesQuery.data)) : new Map();
 
@@ -33,11 +31,7 @@ const useRecipesBase = <T>({
 
 export const useRecipes = () => {
   return useRecipesBase({
-    select: (data) => {
-      const temp = Array.from(data.values())
-      console.log('got temp', temp, data)
-      return temp
-    },
+    select: (data) => Array.from(data.values()),
   });
 };
 

--- a/core/dynamo/hooks/use_dynamo_put.ts
+++ b/core/dynamo/hooks/use_dynamo_put.ts
@@ -1,4 +1,4 @@
-import { IRecipe, IRecipes } from "../../../core/types/recipes";
+import { IRecipe } from "../../../core/types/recipes";
 import {
   IAddOrUpdatePlan,
   addOrUpdatePlan,
@@ -10,6 +10,7 @@ import {
   getRecipesQueryKey,
   getMealPlanQueryKey,
 } from "../../../client/hooks";
+import { GetKitchencalmRecipes200 } from "../../../client/generated/hooks";
 import { useQueryClient } from "@tanstack/react-query";
 
 const useMutateRecipeInCache = () => {
@@ -17,13 +18,13 @@ const useMutateRecipeInCache = () => {
   const recipesKey = getRecipesQueryKey();
 
   return (recipe: IRecipe) => {
-    const previousRecipes: IRecipes | undefined =
-      queryClient.getQueryData(recipesKey);
+    const previousRecipes = queryClient.getQueryData<GetKitchencalmRecipes200>(recipesKey);
 
     if (previousRecipes) {
-      const updatedRecipes = new Map(previousRecipes);
-      updatedRecipes.set(recipe.uuid, recipe);
-      queryClient.setQueryData(recipesKey, updatedRecipes);
+      queryClient.setQueryData(recipesKey, {
+        ...previousRecipes,
+        [recipe.uuid]: recipe,
+      });
     }
 
     return {
@@ -39,9 +40,7 @@ const useMutateMealPlanInCache = () => {
   return (newMealPlan: IMealPlan) => {
     const previousMealPlan = queryClient.getQueryData(mealPlanKey);
 
-    // Wrap in { data: ... } to match the AxiosResponse shape that
-    // useGetMealPlan's select function expects
-    queryClient.setQueryData(mealPlanKey, { data: newMealPlan });
+    queryClient.setQueryData(mealPlanKey, newMealPlan);
 
     return {
       undo: () => {
@@ -61,8 +60,7 @@ export const usePutMealPlanToDynamo = () => {
   return {
     ...updateMealPlan,
     mutate: (update: IAddOrUpdatePlan) => {
-      const cachedData = queryClient.getQueryData(mealPlanKey) as any;
-      const currentMealPlan = cachedData?.data as IMealPlan | undefined;
+      const currentMealPlan = queryClient.getQueryData(mealPlanKey) as IMealPlan | undefined;
       if (!currentMealPlan || !Array.isArray(currentMealPlan)) throw new Error('Cannot modify empty meal plan')
       const updatedMealPlan = addOrUpdatePlan(currentMealPlan, update);
       mutate(updatedMealPlan);

--- a/core/dynamo/hooks/use_parse_recipe.ts
+++ b/core/dynamo/hooks/use_parse_recipe.ts
@@ -1,7 +1,7 @@
 import { useParseRecipe } from '../../../client/hooks';
 import { useQueryClient } from '@tanstack/react-query';
 import { getRecipesQueryKey } from '../../../client/hooks';
-import { AxiosResponse } from 'axios';
+import { GetKitchencalmRecipes200 } from '../../../client/generated/hooks';
 
 /**
  * Hook for parsing recipe text and adding it to the recipe cache
@@ -28,17 +28,13 @@ export const useParsedRecipeToDynamo = () => {
       }
 
       // Update the query cache with the parsed recipe
-      // The cache stores the raw AxiosResponse, not the extracted data
-      const cachedResponse = queryClient.getQueryData(recipesKey) as AxiosResponse | undefined;
+      const cachedRecipes = queryClient.getQueryData<GetKitchencalmRecipes200>(recipesKey);
       const recipeUuid = recipeId || parsedRecipe.uuid;
 
-      if (cachedResponse?.data) {
+      if (cachedRecipes) {
         queryClient.setQueryData(recipesKey, {
-          ...cachedResponse,
-          data: {
-            ...cachedResponse.data,
-            [recipeUuid]: parsedRecipe,
-          },
+          ...cachedRecipes,
+          [recipeUuid]: parsedRecipe,
         });
       } else {
         // No cached data yet — invalidate so /food refetches from the server

--- a/core/storage/use_hydrate_cache_from_indexed_db.ts
+++ b/core/storage/use_hydrate_cache_from_indexed_db.ts
@@ -7,9 +7,7 @@ import { getRecipesQueryKey, getMealPlanQueryKey } from "../../client/hooks";
 /**
  * Seeds the react-query cache from IndexedDB on mount so recipes/meal plan
  * can render instantly on first paint, without waiting for auth to resolve
- * or the network request to complete. The Orval-generated query functions
- * cache a raw axios-response-shaped object, so we wrap the stored payload
- * in `{ data: payload }` to match what `select` expects to unwrap.
+ * or the network request to complete.
  *
  * It doesn't matter whose data this is or whether the session is still
  * valid - we just show whatever is cached. useAppSession clears IndexedDB
@@ -27,15 +25,14 @@ export const useHydrateCacheFromIndexedDb = () => {
     const mealPlanKey = getMealPlanQueryKey();
 
     idbGet(RECIPES_CACHE_KEY).then((payload) => {
-      console.log('existing data', queryClient.getQueryData(recipesKey))
       if (payload !== undefined && queryClient.getQueryData(recipesKey) === undefined) {
-        queryClient.setQueryData(recipesKey, { data: payload });
+        queryClient.setQueryData(recipesKey, payload);
       }
     });
 
     idbGet(MEAL_PLAN_CACHE_KEY).then((payload) => {
       if (payload !== undefined && queryClient.getQueryData(mealPlanKey) === undefined) {
-        queryClient.setQueryData(mealPlanKey, { data: payload });
+        queryClient.setQueryData(mealPlanKey, payload);
       }
     });
   }, [queryClient]);

--- a/test/core/dynamo/hooks/use_dynamo_delete.test.ts
+++ b/test/core/dynamo/hooks/use_dynamo_delete.test.ts
@@ -1,7 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
-import { AxiosResponse } from "axios";
 import { useDeleteRecipeFromDynamo } from "../../../../core/dynamo/hooks/use_dynamo_delete";
 import {
   GetKitchencalmRecipes200,
@@ -29,28 +28,6 @@ jest.mock("../../../../client/hooks", () => {
 const recipesKey = getGetKitchencalmRecipesQueryKey();
 const mealPlanKey = getGetKitchencalmMealPlanQueryKey();
 
-function makeRecipesResponse(
-  data: GetKitchencalmRecipes200
-): AxiosResponse<GetKitchencalmRecipes200> {
-  return {
-    data,
-    status: 200,
-    statusText: "OK",
-    headers: {},
-    config: {} as AxiosResponse["config"],
-  };
-}
-
-function makeMealPlanResponse(data: MealPlan): AxiosResponse<MealPlan> {
-  return {
-    data,
-    status: 200,
-    statusText: "OK",
-    headers: {},
-    config: {} as AxiosResponse["config"],
-  };
-}
-
 describe("useDeleteRecipeFromDynamo", () => {
   let queryClient: QueryClient;
 
@@ -69,53 +46,47 @@ describe("useDeleteRecipeFromDynamo", () => {
     });
 
     it("removes the recipe from the recipes cache", async () => {
-      queryClient.setQueryData(
-        recipesKey,
-        makeRecipesResponse({
-          "recipe-1": { uuid: "recipe-1", name: "Pasta", description: "", images: [], components: [] },
-          "recipe-2": { uuid: "recipe-2", name: "Salad", description: "", images: [], components: [] },
-        })
-      );
+      queryClient.setQueryData<GetKitchencalmRecipes200>(recipesKey, {
+        "recipe-1": { uuid: "recipe-1", name: "Pasta", description: "", images: [], components: [] },
+        "recipe-2": { uuid: "recipe-2", name: "Salad", description: "", images: [], components: [] },
+      });
 
       const { result } = renderHook(() => useDeleteRecipeFromDynamo(), { wrapper });
       await act(async () => {
         await result.current.mutateAsync("recipe-1");
       });
 
-      const cached = queryClient.getQueryData<AxiosResponse<GetKitchencalmRecipes200>>(recipesKey);
-      expect(Object.keys(cached!.data)).toEqual(["recipe-2"]);
+      const cached = queryClient.getQueryData<GetKitchencalmRecipes200>(recipesKey);
+      expect(Object.keys(cached!)).toEqual(["recipe-2"]);
     });
 
     it("removes all references to the recipe from the meal plan cache", async () => {
-      queryClient.setQueryData(
-        mealPlanKey,
-        makeMealPlanResponse([
-          {
-            date: 1000,
-            plan: [
-              { recipeId: "recipe-1", components: [{ componentId: "c1", servings: 2 }] },
-              { recipeId: "recipe-2", components: [{ componentId: "c2", servings: 1 }] },
-            ],
-          },
-          {
-            date: 2000,
-            plan: [
-              { recipeId: "recipe-1", components: [{ componentId: "c1", servings: 3 }] },
-            ],
-          },
-        ])
-      );
+      queryClient.setQueryData<MealPlan>(mealPlanKey, [
+        {
+          date: 1000,
+          plan: [
+            { recipeId: "recipe-1", components: [{ componentId: "c1", servings: 2 }] },
+            { recipeId: "recipe-2", components: [{ componentId: "c2", servings: 1 }] },
+          ],
+        },
+        {
+          date: 2000,
+          plan: [
+            { recipeId: "recipe-1", components: [{ componentId: "c1", servings: 3 }] },
+          ],
+        },
+      ]);
 
       const { result } = renderHook(() => useDeleteRecipeFromDynamo(), { wrapper });
       await act(async () => {
         await result.current.mutateAsync("recipe-1");
       });
 
-      const cached = queryClient.getQueryData<AxiosResponse<MealPlan>>(mealPlanKey);
-      expect(cached!.data[0].plan).toEqual([
+      const cached = queryClient.getQueryData<MealPlan>(mealPlanKey);
+      expect(cached![0].plan).toEqual([
         { recipeId: "recipe-2", components: [{ componentId: "c2", servings: 1 }] },
       ]);
-      expect(cached!.data[1].plan).toEqual([]);
+      expect(cached![1].plan).toEqual([]);
     });
 
     it("does nothing when the recipes cache is absent", async () => {
@@ -127,12 +98,9 @@ describe("useDeleteRecipeFromDynamo", () => {
     });
 
     it("does nothing to the meal plan when the meal plan cache is absent", async () => {
-      queryClient.setQueryData(
-        recipesKey,
-        makeRecipesResponse({
-          "recipe-1": { uuid: "recipe-1", name: "Pasta", description: "", images: [], components: [] },
-        })
-      );
+      queryClient.setQueryData<GetKitchencalmRecipes200>(recipesKey, {
+        "recipe-1": { uuid: "recipe-1", name: "Pasta", description: "", images: [], components: [] },
+      });
 
       const { result } = renderHook(() => useDeleteRecipeFromDynamo(), { wrapper });
       await act(async () => {
@@ -149,20 +117,17 @@ describe("useDeleteRecipeFromDynamo", () => {
     });
 
     it("rolls back the recipes cache", async () => {
-      queryClient.setQueryData(
-        recipesKey,
-        makeRecipesResponse({
-          "recipe-1": { uuid: "recipe-1", name: "Pasta", description: "", images: [], components: [] },
-        })
-      );
+      queryClient.setQueryData<GetKitchencalmRecipes200>(recipesKey, {
+        "recipe-1": { uuid: "recipe-1", name: "Pasta", description: "", images: [], components: [] },
+      });
 
       const { result } = renderHook(() => useDeleteRecipeFromDynamo(), { wrapper });
       await act(async () => {
         await expect(result.current.mutateAsync("recipe-1")).rejects.toThrow("network error");
       });
 
-      const cached = queryClient.getQueryData<AxiosResponse<GetKitchencalmRecipes200>>(recipesKey);
-      expect(Object.keys(cached!.data)).toContain("recipe-1");
+      const cached = queryClient.getQueryData<GetKitchencalmRecipes200>(recipesKey);
+      expect(Object.keys(cached!)).toContain("recipe-1");
     });
 
     it("rolls back the meal plan cache", async () => {
@@ -172,16 +137,16 @@ describe("useDeleteRecipeFromDynamo", () => {
           plan: [{ recipeId: "recipe-1", components: [{ componentId: "c1", servings: 2 }] }],
         },
       ];
-      queryClient.setQueryData(mealPlanKey, makeMealPlanResponse(originalPlan));
+      queryClient.setQueryData<MealPlan>(mealPlanKey, originalPlan);
 
       const { result } = renderHook(() => useDeleteRecipeFromDynamo(), { wrapper });
       await act(async () => {
         await expect(result.current.mutateAsync("recipe-1")).rejects.toThrow("network error");
       });
 
-      const cached = queryClient.getQueryData<AxiosResponse<MealPlan>>(mealPlanKey);
-      expect(cached!.data[0].plan).toHaveLength(1);
-      expect(cached!.data[0].plan[0].recipeId).toBe("recipe-1");
+      const cached = queryClient.getQueryData<MealPlan>(mealPlanKey);
+      expect(cached![0].plan).toHaveLength(1);
+      expect(cached![0].plan[0].recipeId).toBe("recipe-1");
     });
 
     it("re-throws the error", async () => {


### PR DESCRIPTION
## Summary
- The custom `axiosInstance` (`src/lib/axios.ts`) already unwraps the axios response (`.then(({ data }) => data)`), so the react-query cache holds the raw payload directly, not an `AxiosResponse`-shaped `{ data: ... }` object.
- `useGetRecipes`/`useGetMealPlan` in `client/hooks.ts` applied an extra `select: response => response.data` on top of that, which returned `undefined` — causing recipes/meal plan to appear empty in the UI even though `getQueryData` showed real cached data.
- The same incorrect assumption was repeated in `use_dynamo_put.ts` (meal plan updates — this caused `"Cannot modify empty meal plan"` errors when dragging recipes onto the calendar), `use_dynamo_delete.ts` (recipe delete optimistic update/rollback), and `use_parse_recipe.ts` (saving parsed recipes into cache).
- Removed the redundant `.data` unwraps and unwrapped re-wraps across all of these, and simplified IndexedDB hydration to store/read the payload directly.
- Updated `use_dynamo_delete.test.ts` to match the real (unwrapped) cache shape.

## Test plan
- [x] `yarn test` — all suites pass except one pre-existing, unrelated failure (`import.meta` not supported by current ts-jest config in `src/lib/axios.ts`, fails identically before this change)
- [ ] Manually verify recipes and meal plan render with real data after sign-in
- [ ] Manually verify dragging a recipe onto the meal plan calendar works without the "Cannot modify empty meal plan" error


---
_Generated by [Claude Code](https://claude.ai/code/session_011KJvWPfdSTKuy32rFAaeah)_