### PR TITLE
Standardize query keys and refresh data on cache restore

### DIFF
--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -32,8 +32,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (isAuthenticated && !previousAuthState.current) {
       // User just logged in, invalidate to fetch fresh data
-      queryClient.invalidateQueries({ queryKey: ['kitchencalm', 'recipes'] });
-      queryClient.invalidateQueries({ queryKey: ['kitchencalm', 'meal-plan'] });
+      queryClient.invalidateQueries({ queryKey: ['/kitchencalm/recipes'] });
+      queryClient.invalidateQueries({ queryKey: ['/kitchencalm/meal-plan'] });
     }
     previousAuthState.current = isAuthenticated;
   }, [isAuthenticated, queryClient]);

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1,6 +1,10 @@
 import React, { createContext, useContext, useEffect, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getSession, signIn, signOut, User } from './auth-api';
+import {
+  getGetKitchencalmRecipesQueryKey,
+  getGetKitchencalmMealPlanQueryKey,
+} from '@/client/generated/hooks';
 
 interface AuthContextValue {
   user: User | null;
@@ -32,8 +36,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (isAuthenticated && !previousAuthState.current) {
       // User just logged in, invalidate to fetch fresh data
-      queryClient.invalidateQueries({ queryKey: ['/kitchencalm/recipes'] });
-      queryClient.invalidateQueries({ queryKey: ['/kitchencalm/meal-plan'] });
+      queryClient.invalidateQueries({
+        queryKey: getGetKitchencalmRecipesQueryKey(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: getGetKitchencalmMealPlanQueryKey(),
+      });
     }
     previousAuthState.current = isAuthenticated;
   }, [isAuthenticated, queryClient]);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,10 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { AuthProvider } from "./auth/AuthProvider";
 import { App } from "./App";
 import { createIDBPersister } from "./lib/query-persister";
+import {
+  getGetKitchencalmRecipesQueryKey,
+  getGetKitchencalmMealPlanQueryKey,
+} from "@/client/generated/hooks";
 
 // Self-hosted fonts - only load weights we use (400, 500, 600, 700)
 import "@fontsource/dm-sans/400.css";
@@ -42,9 +46,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       onSuccess={() => {
         // Cache restored from IndexedDB on full reload - refetch recipes and
         // meal plan in the background so stale persisted data doesn't linger.
-        queryClient.invalidateQueries({ queryKey: ["/kitchencalm/recipes"] });
         queryClient.invalidateQueries({
-          queryKey: ["/kitchencalm/meal-plan"],
+          queryKey: getGetKitchencalmRecipesQueryKey(),
+        });
+        queryClient.invalidateQueries({
+          queryKey: getGetKitchencalmMealPlanQueryKey(),
         });
       }}
     >

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -39,6 +39,14 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <PersistQueryClientProvider
       client={queryClient}
       persistOptions={{ persister }}
+      onSuccess={() => {
+        // Cache restored from IndexedDB on full reload - refetch recipes and
+        // meal plan in the background so stale persisted data doesn't linger.
+        queryClient.invalidateQueries({ queryKey: ["/kitchencalm/recipes"] });
+        queryClient.invalidateQueries({
+          queryKey: ["/kitchencalm/meal-plan"],
+        });
+      }}
     >
       <ReactQueryDevtools initialIsOpen={false} />
       <AuthProvider>


### PR DESCRIPTION
## Summary
This PR standardizes query key format across the codebase and adds automatic data refresh when the persisted cache is restored from IndexedDB on full page reload.

## Key Changes
- **Standardized query keys**: Updated query key format from array notation (`['kitchencalm', 'recipes']`) to path notation (`['/kitchencalm/recipes']`) in `AuthProvider.tsx` for consistency
- **Added cache restoration handler**: Implemented `onSuccess` callback in `PersistQueryClientProvider` to invalidate recipes and meal plan queries when the persisted cache is restored, ensuring fresh data is fetched in the background and preventing stale data from lingering after a full reload

## Implementation Details
The `onSuccess` callback in the `PersistQueryClientProvider` fires when IndexedDB cache restoration completes. This triggers background refetches of the recipes and meal plan queries, keeping the UI in sync with the latest server data while maintaining the performance benefits of cache persistence.

https://claude.ai/code/session_014DaGFLb4rZgVG375p2j56L