### PR TITLE
Add Wrangler configuration for Cloudflare Workers deployment

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "name": "mise",
+  "compatibility_date": "2026-06-28",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a `wrangler.jsonc` configuration file to enable deployment of the project to Cloudflare Workers.

## Changes
- Added `wrangler.jsonc` with configuration for:
  - Project name: "mise"
  - Compatibility date: 2026-06-28
  - Static asset serving from the `./dist` directory
  - Single-page application routing for unmatched paths

## Implementation Details
The configuration enables the project to be deployed as a Cloudflare Workers application with static asset hosting. The `not_found_handling: "single-page-application"` setting ensures that all unmatched routes are handled by the SPA, allowing client-side routing to work correctly.

https://claude.ai/code/session_01A7KNTvUVnoitZUSKAFFWAF