### PR TITLE
Add favicon link to HTML head

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <title>Mise</title>
 
     <!-- Critical inline CSS for instant loading state -->


### PR DESCRIPTION
## Summary
Added a favicon link to the HTML document head to enable browser tab icon display.

## Changes
- Added `<link rel="icon" href="/favicon.ico" sizes="any" />` to the `<head>` section of `index.html`
- This allows the browser to load and display a favicon from the `/favicon.ico` file in the public directory

## Implementation Details
- The favicon link is placed after the viewport meta tag and before the title tag
- Uses the `sizes="any"` attribute to support favicon files of any size
- The favicon file itself should be placed in the public directory as `/favicon.ico`

https://claude.ai/code/session_01SfHwinN3gH2ruHSwi9avRk